### PR TITLE
SCRUM-19 Fix Thymeleaf club info page to use Java field names (not DB…

### DIFF
--- a/src/main/resources/templates/club-info.html
+++ b/src/main/resources/templates/club-info.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <title th:text="${club.clubName}">Club Info</title>
-  <meta charset="UTF-8">
+    <title th:text="${club.name}">Club Info</title>
+    <meta charset="UTF-8">
 </head>
 <body>
-<h1 th:text="${club.clubName}">Club Name</h1>
-<p><strong>Description:</strong> <span th:text="${club.clubDescription}">Description</span></p>
-<p><strong>Category:</strong> <span th:text="${club.clubCategory}">Category</span></p>
-<p><strong>Contact Email:</strong> <span th:text="${club.clubContactEmail}">Contact Email</span></p>
-<p><strong>Approved:</strong> <span th:text="${club.clubIsApproved}">Approved</span></p>
-<p><strong>Created At:</strong> <span th:text="${club.clubCreatedAt}">Created At</span></p>
-<p><strong>Updated At:</strong> <span th:text="${club.clubUpdatedAt}">Updated At</span></p>
+<h1 th:text="${club.name}">Club Name</h1>
+<p><strong>Description:</strong> <span th:text="${club.description}">Description</span></p>
+<p><strong>Category:</strong> <span th:text="${club.category}">Category</span></p>
+<p><strong>Contact Email:</strong> <span th:text="${club.contactEmail}">Contact Email</span></p>
+<p><strong>Approved:</strong> <span th:text="${club.isApproved}">Approved</span></p>
+<p><strong>Created At:</strong> <span th:text="${club.createdAt}">Created At</span></p>
+<p><strong>Updated At:</strong> <span th:text="${club.updatedAt}">Updated At</span></p>
 <p>
-  <strong>University:</strong>
-  <span th:if="${club.university != null}" th:text="${club.university.universityName}">University Name</span>
-  <span th:if="${club.university == null}">N/A</span>
+    <strong>University:</strong>
+    <span th:if="${club.university != null}" th:text="${club.university.universityName}">University Name</span>
+    <span th:if="${club.university == null}">N/A</span>
 </p>
 </body>
 </html>


### PR DESCRIPTION
… column names)

         - Updated club-info.html to use Java entity field names (e.g., contactEmail, isApproved, createdAt) instead of database column names (e.g., contactemail, isapproved, createdat).
         - This resolves Thymeleaf template errors and allows the club info page to render correctly.
         - Verified that http://localhost:8080/clubs/e7bf8004-7a43-49ff-937d-e574ede341b1 displays all club details as expected.