### PR TITLE
SCRUM-19 Show members with roles on club info page

### DIFF
--- a/src/main/java/com/example/clubhub/controller/ClubPageController.java
+++ b/src/main/java/com/example/clubhub/controller/ClubPageController.java
@@ -1,7 +1,9 @@
 package com.example.clubhub.controller;
 
 import com.example.clubhub.model.Club;
+import com.example.clubhub.model.User;
 import com.example.clubhub.repository.ClubRepository;
+import com.example.clubhub.repository.UserRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -13,9 +15,11 @@ import java.util.UUID;
 public class ClubPageController {
 
     private final ClubRepository clubRepository;
+    private final UserRepository userRepository;
 
-    public ClubPageController(ClubRepository clubRepository) {
+    public ClubPageController(ClubRepository clubRepository, UserRepository userRepository) {
         this.clubRepository = clubRepository;
+        this.userRepository = userRepository;
     }
 
     // Show all clubs, with optional search by name
@@ -31,12 +35,13 @@ public class ClubPageController {
         return "club-list";
     }
 
-    // Show info for a single club
+    // Show info for a single club, including members
     @GetMapping("/clubs/{id}")
     public String clubInfo(@PathVariable UUID id, Model model) {
         Club club = clubRepository.findById(id).orElse(null);
+        List<User> members = userRepository.findByClubId(id);
         model.addAttribute("club", club);
-        // You can add members and posts here later!
+        model.addAttribute("members", members);
         return "club-info";
     }
 }

--- a/src/main/resources/templates/club-info.html
+++ b/src/main/resources/templates/club-info.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
 </head>
 <body>
+<a href="/clubs">Back to club list</a>
 <h1 th:text="${club.name}">Club Name</h1>
 <p><strong>Description:</strong> <span th:text="${club.description}">Description</span></p>
 <p><strong>Category:</strong> <span th:text="${club.category}">Category</span></p>
@@ -17,5 +18,14 @@
     <span th:if="${club.university != null}" th:text="${club.university.universityName}">University Name</span>
     <span th:if="${club.university == null}">N/A</span>
 </p>
+
+<hr>
+<h2>Members</h2>
+<ul>
+    <li th:each="member : ${members}">
+        <span th:text="${member.userName}">Member Name</span>
+        <span th:text="'(' + ${member.role} + ')'">Role</span>
+    </li>
+</ul>
 </body>
 </html>

--- a/src/main/resources/templates/club-list.html
+++ b/src/main/resources/templates/club-list.html
@@ -2,16 +2,21 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Clubs</title>
+    <meta charset="UTF-8">
 </head>
 <body>
 <h1>Clubs</h1>
 <form method="get" th:action="@{/clubs}">
-    <input type="text" name="name" placeholder="Search clubs by name"/>
+    <input type="text" name="name" placeholder="Search clubs by name" th:value="${param.name}" />
     <button type="submit">Search</button>
 </form>
 <ul>
     <li th:each="club : ${clubs}">
         <a th:href="@{'/clubs/' + ${club.id}}" th:text="${club.name}"></a>
+        <span th:text="' - ' + ${club.category}"></span>
+        <span th:if="${club.university != null}"> (</span>
+        <span th:if="${club.university != null}" th:text="${club.university.universityName}"></span>
+        <span th:if="${club.university != null}">)</span>
     </li>
 </ul>
 </body>


### PR DESCRIPTION
         - Updated ClubPageController to fetch and add club members to the model for the club info view.
         - Updated club-info.html to display a list of members and their roles for each club.
         - Now, when viewing a club (e.g. http://localhost:8080/clubs/e7bf8004-7a43-49ff-937d-e574ede341b1), users can see all members and their roles under a "Members" section.